### PR TITLE
chore: bump npm package version to 3.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "netbox-docker-image-upgrade",
-    "version": "3.7.1",
+    "version": "3.7.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "netbox-docker-image-upgrade",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "netbox-docker-image-upgrade",
-    "version": "3.7.1",
+    "version": "3.7.2",
     "description": "App to deploy new image to all containers",
     "author": "vincent@saashup.com",
     "homepage": "https://github.com/SaaShup/netbox-docker-image-upgrade",


### PR DESCRIPTION
### Motivation
- Bump the npm package version to allow tagging and release of the new patch.

### Description
- Update the `version` field from `3.7.1` to `3.7.2` in `package.json` and the root package entry in `package-lock.json`.

### Testing
- Ran `npm version patch --no-git-tag-version` and verified the result with `npm pkg get version`, which returned `3.7.2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271f3d1064833398e246350a0d1ab2)