### PR TITLE
Send ready email for enroll requests, add SMTP test, and bump version to 3.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "netbox-docker-image-upgrade",
-    "version": "3.7.2",
+    "version": "3.7.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "netbox-docker-image-upgrade",
-            "version": "3.7.2",
+            "version": "3.7.3",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "netbox-docker-image-upgrade",
-    "version": "3.7.2",
+    "version": "3.7.3",
     "description": "App to deploy new image to all containers",
     "author": "vincent@saashup.com",
     "homepage": "https://github.com/SaaShup/netbox-docker-image-upgrade",

--- a/server.js
+++ b/server.js
@@ -1835,7 +1835,7 @@ async function createInstance(req, data, { isOrderRequest, isEnrollRequest, orde
   }
 
   const allReady = readyCount === targetHosts.length;
-  if (isOrderRequest && allReady) {
+  if ((isOrderRequest || isEnrollRequest) && allReady) {
     try {
       await sendOrderReadyEmail(data, authUser.email || "");
     } catch (error) {

--- a/tests/unit/server-routes.test.js
+++ b/tests/unit/server-routes.test.js
@@ -2078,10 +2078,12 @@ describe("server routes", () => {
   });
 
   test("enforces enrollment limits separately from order requests", async () => {
-    const { dataPath, fetchMock, request } = await loadServer();
+    const { dataPath, fetchMock, request, setSmtpSenderForTests } = await loadServer({ ownerEmail: "owner@example.com" });
     setupNetBoxFetch(fetchMock, { expectTraefikConfig: false });
+    const smtpSender = vi.fn().mockResolvedValue({ messageId: "enroll-ready-message", accepted: ["buyer@example.com"], response: "250 queued" });
+    setSmtpSenderForTests(smtpSender);
     writeState(dataPath, {
-      config: { netbox: "https://netbox.example.com", token: "secret", max_templates: 1, profile: "prod", config_profile: "prod" },
+      config: { netbox: "https://netbox.example.com", token: "secret", max_templates: 1, profile: "prod", config_profile: "prod", smtp_config: "mailer:smtp-secret@smtp.example.com:587" },
       templates: {},
       order_counts: {},
       order_instances: {},
@@ -2136,6 +2138,17 @@ describe("server routes", () => {
         { key: "saashup.template.port", value: "8080" },
       ]));
     });
+    await vi.waitFor(() => expect(smtpSender).toHaveBeenCalledWith(
+      expect.objectContaining({ user: "mailer", password: "smtp-secret", host: "smtp.example.com", port: 587 }),
+      expect.objectContaining({
+        from: "owner@example.com",
+        to: "buyer@example.com",
+        cc: ["owner@example.com"],
+        subject: "enroll-one.example.com is ready",
+        text: expect.stringContaining("Your instance is now running: enroll-one.example.com"),
+      }),
+    ));
+    expect(readState(dataPath).logs).toContain("EMAIL : ready notification sent to buyer@example.com for enroll-one.example.com");
 
     await request.get("/enroll/limit")
       .set("x-auth-request-email", "buyer@example.com")


### PR DESCRIPTION
### Motivation
- Ensure enrollment requests also produce a "ready" notification email when instances become ready similar to order requests.
- Add test coverage for SMTP sending and logging for enrollment flows.
- Bump package version to reflect the change.

### Description
- Updated the readiness check in `server.js` to send the ready email when `(isOrderRequest || isEnrollRequest) && allReady` instead of only for order requests. 
- Left enrollment status update and logging intact via `updateEnrollmentInstanceStatus` and other existing flows. 
- Adjusted unit test `tests/unit/server-routes.test.js` to initialize the test server with an `ownerEmail`, to register a mocked SMTP sender via `setSmtpSenderForTests`, and to include `smtp_config` in the written state so the SMTP send path is exercised. 
- Bumped `version` in `package.json` and `package-lock.json` from `3.7.2` to `3.7.3`.

### Testing
- Ran unit tests with `vitest` (`npm run test:unit`) which include the updated enrollment test that asserts the mocked SMTP sender is called and that the log contains the ready-email entry, and the tests passed.
- No end-to-end tests were modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2724c4b31883339efef5757b3d3acf)