### PR TITLE
Add SMTP client name and retry logic; make enrollment template names linkable

### DIFF
--- a/lib/smtp.js
+++ b/lib/smtp.js
@@ -1,5 +1,9 @@
 const nodemailer = require("nodemailer");
 
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function parseSmtpConfig(value) {
   const text = String(value || "").trim();
   if (!text) return null;
@@ -27,8 +31,19 @@ function smtpSenderAddress(config, fallbackEmail = "") {
   return `no-reply@${domain}`;
 }
 
+function smtpClientName(config) {
+  const userDomain = String(config.user || "").split("@")[1];
+  if (userDomain && userDomain.includes(".")) return userDomain.toLowerCase();
+
+  const host = String(config.host || "").replace(/^smtp\./i, "").toLowerCase();
+  if (host && host.includes(".")) return host;
+
+  return "localhost.localdomain";
+}
+
 function smtpTransportOptions(config, timeoutMs) {
   return {
+    name: smtpClientName(config),
     host: config.host,
     port: config.port,
     secure: Boolean(config.secure),
@@ -59,17 +74,45 @@ function smtpMessage(message) {
   };
 }
 
-async function sendSmtpMail(config, message, { timeoutMs = 10000 } = {}) {
-  const transporter = nodemailer.createTransport(smtpTransportOptions(config, timeoutMs));
-  return transporter.sendMail(smtpMessage({
+function isTransientSmtpError(error) {
+  const responseCode = Number(error?.responseCode || error?.code);
+  if (responseCode >= 400 && responseCode < 500) return true;
+
+  const errorCode = String(error?.code || "").toUpperCase();
+  if (["ECONNRESET", "ETIMEDOUT", "ESOCKET"].includes(errorCode)) return true;
+
+  const text = [error?.message, error?.response].filter(Boolean).join("\n");
+  return /(^|\D)4\d\d(?:\D|$)|try again later|temporar/i.test(text);
+}
+
+async function sendSmtpMail(config, message, { timeoutMs = 10000, retries = 2, retryDelayMs = 2000 } = {}) {
+  const payload = smtpMessage({
     ...message,
     from: message.from || smtpSenderAddress(config),
-  }));
+  });
+  const attempts = Math.max(1, Number(retries) + 1 || 1);
+  let lastError;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const transporter = nodemailer.createTransport(smtpTransportOptions(config, timeoutMs));
+    try {
+      return await transporter.sendMail(payload);
+    } catch (error) {
+      lastError = error;
+      if (attempt >= attempts || !isTransientSmtpError(error)) throw error;
+      await delay(retryDelayMs * attempt);
+    } finally {
+      if (typeof transporter.close === "function") transporter.close();
+    }
+  }
+
+  throw lastError;
 }
 
 module.exports = {
   parseSmtpConfig,
   sendSmtpMail,
+  smtpClientName,
   smtpSenderAddress,
   smtpMessage,
   smtpTransportOptions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "netbox-docker-image-upgrade",
-    "version": "3.7.3",
+    "version": "3.7.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "netbox-docker-image-upgrade",
-            "version": "3.7.3",
+            "version": "3.7.4",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "netbox-docker-image-upgrade",
-    "version": "3.7.3",
+    "version": "3.7.4",
     "description": "App to deploy new image to all containers",
     "author": "vincent@saashup.com",
     "homepage": "https://github.com/SaaShup/netbox-docker-image-upgrade",

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2423,12 +2423,22 @@ function enrollTemplateDeleteTitle(item) {
   return "Delete unavailable for this template source";
 }
 
+function enrollmentTemplateNameLink(item) {
+  const name = String(item?.instance || "").trim();
+  if (!name) return "<strong>SaaShup template</strong>";
+
+  const href = orderTemplateUrl(name);
+  if (!href) return `<strong>${escapeHtml(name)}</strong>`;
+
+  return `<a class="order-instance-link" href="${escapeHtml(href)}">${escapeHtml(name)}</a>`;
+}
+
 function enrollmentTemplateTitle(item) {
   const count = Number(item?.instance_count || 0);
   const badgeLabel = `${count} instance${count === 1 ? "" : "s"}`;
   return `
     <span class="enroll-template-title">
-      ${orderInstanceNameLink(item.instance, item.dns_name)}
+      ${enrollmentTemplateNameLink(item)}
       <span class="enroll-template-count" title="${escapeHtml(badgeLabel)}" aria-label="${escapeHtml(badgeLabel)}">${count}</span>
     </span>
   `;

--- a/server.js
+++ b/server.js
@@ -39,7 +39,7 @@ const { NetBoxClient, dockerHosts, hostIdQuery, setNetBoxFetchForTests } = requi
 const { createOidcAuth, setOidcFetchForTests } = require("./lib/oidc");
 const { createOperationHelpers, delay } = require("./lib/operations");
 const { checkRegistryImageExists, setRegistryFetchForTests } = require("./lib/registry");
-const { parseSmtpConfig, sendSmtpMail, smtpMessage, smtpSenderAddress, smtpTransportOptions } = require("./lib/smtp");
+const { parseSmtpConfig, sendSmtpMail, smtpClientName, smtpMessage, smtpSenderAddress, smtpTransportOptions } = require("./lib/smtp");
 const { createStateStore, parseProfiles, plainObject } = require("./lib/state");
 
 const app = express();
@@ -1992,6 +1992,7 @@ module.exports = {
   setTurnstileFetchForTests: (fetcher) => {
     turnstileFetch = fetcher || undiciFetch;
   },
+  smtpClientName,
   smtpMessage,
   smtpSenderAddress,
   smtpTransportOptions,

--- a/tests/e2e/admin.spec.js
+++ b/tests/e2e/admin.spec.js
@@ -2712,6 +2712,7 @@ test("enroll page shows templates created by the user", async ({ page }) => {
   await expect(page.locator("#enrollInstances .order-instance-delete").nth(1)).toBeEnabled();
   await expect(page.locator("#enrollInstances .order-instance-delete svg").first()).toBeVisible();
   await expect(page.locator("#enrollInstances .order-template-copy").first()).toBeVisible();
+  await expect(page.locator("#enrollInstances .enroll-template-title a").first()).toHaveAttribute("href", `${page.url().replace(/\/enroll(?:\.html)?$/, "")}/order?template=guide-template&profile=production`);
   await page.locator("#enrollInstances .order-template-copy").first().click();
   await expect(page.locator("#notif")).toContainText('Order link copied for "guide-template"');
   await expect.poll(() => page.evaluate(() => window.__copiedOrderLink)).toBe(`${page.url().replace(/\/enroll(?:\.html)?$/, "")}/order?template=guide-template&profile=production`);

--- a/tests/unit/server.test.js
+++ b/tests/unit/server.test.js
@@ -21,6 +21,7 @@ const {
   plainObject,
   routeLabel,
   sendSmtpMail,
+  smtpClientName,
   smtpMessage,
   smtpSenderAddress,
   smtpTransportOptions,
@@ -147,7 +148,11 @@ describe("server helpers", () => {
     expect(smtpSenderAddress({})).toBe("no-reply@localhost");
     expect(smtpSenderAddress({ host: "" })).toBe("no-reply@localhost");
     expect(smtpSenderAddress({ host: "smtp." })).toBe("no-reply@localhost");
+    expect(smtpClientName(parseSmtpConfig("contact@example.com:smtp-secret@smtp.example.com:587"))).toBe("example.com");
+    expect(smtpClientName(parseSmtpConfig("mailer:smtp-secret@smtp.example.com:587"))).toBe("example.com");
+    expect(smtpClientName({ host: "localhost" })).toBe("localhost.localdomain");
     expect(smtpTransportOptions(config, 1234)).toMatchObject({
+      name: "example.com",
       host: "smtp.example.com",
       port: 587,
       secure: false,
@@ -198,6 +203,7 @@ describe("server helpers", () => {
     )).resolves.toEqual({ messageId: "queued" });
 
     expect(createTransport).toHaveBeenCalledWith(expect.objectContaining({
+      name: "example.com",
       host: "smtp.example.com",
       port: 587,
       requireTLS: true,
@@ -210,6 +216,30 @@ describe("server helpers", () => {
       subject: "Subject",
       attachments: [expect.objectContaining({ cid: "logo", encoding: "base64" })],
     }));
+
+    createTransport.mockRestore();
+  });
+
+  test("retries transient smtp failures with a fresh transport", async () => {
+    const firstSendMail = vi.fn().mockRejectedValue(Object.assign(new Error("421-4.7.0 Try again later, closing connection. (EHLO)"), { responseCode: 421 }));
+    const secondSendMail = vi.fn().mockResolvedValue({ messageId: "queued-after-retry" });
+    const firstClose = vi.fn();
+    const secondClose = vi.fn();
+    const createTransport = vi.spyOn(nodemailer, "createTransport")
+      .mockReturnValueOnce({ sendMail: firstSendMail, close: firstClose })
+      .mockReturnValueOnce({ sendMail: secondSendMail, close: secondClose });
+
+    await expect(sendSmtpMail(
+      parseSmtpConfig("contact@example.com:smtp-secret@smtp.example.com:587"),
+      { to: "to@example.com", subject: "Subject", text: "Text" },
+      { retries: 1, retryDelayMs: 1 },
+    )).resolves.toEqual({ messageId: "queued-after-retry" });
+
+    expect(createTransport).toHaveBeenCalledTimes(2);
+    expect(firstSendMail).toHaveBeenCalledTimes(1);
+    expect(secondSendMail).toHaveBeenCalledTimes(1);
+    expect(firstClose).toHaveBeenCalledTimes(1);
+    expect(secondClose).toHaveBeenCalledTimes(1);
 
     createTransport.mockRestore();
   });


### PR DESCRIPTION
### Motivation

- Improve SMTP reliability by detecting transient errors and retrying sends with fresh transports to avoid stale/closed connections. 
- Provide a sensible SMTP client `name` for the transport to improve server-side identification. 
- Make enrollment template names link to the order page for easier UX when templates have an order URL. 

### Description

- Add `delay` and `isTransientSmtpError` helpers and implement retry/backoff in `sendSmtpMail` with configurable `retries` and `retryDelayMs`, ensuring transports are closed after each attempt. 
- Add `smtpClientName` and include it as the `name` field in `smtpTransportOptions`, and export `smtpClientName` from the server module. 
- Update frontend by adding `enrollmentTemplateNameLink` and using it in the enroll template title so template names render as links when an order URL is available. 
- Bump package version to `3.7.4` in `package.json`/`package-lock.json` and update unit and e2e tests to cover the new SMTP behavior and the enrollment template link. 

### Testing

- Ran unit tests with `vitest` which include new tests for `smtpClientName`, transport `name` propagation, and retrying transient failures in `sendSmtpMail`, and they passed. 
- Ran end-to-end tests with `playwright` which include a check that enrollment template names render as links, and the updated e2e test passed. 
- Verified that the modified `sendSmtpMail` closes transports after attempts and returns the successful `sendMail` result when a retry succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27a2605520833380ede26191fa22bc)