### PR TITLE
Support fetching enrollment templates across owners (owner_only query) and catalog fix

### DIFF
--- a/api/enroll.js
+++ b/api/enroll.js
@@ -27,8 +27,8 @@ function createEnrollHelpers({
   workflowsForRequest,
   writeState,
 }) {
-  async function currentEnrollmentUsage(req, profile) {
-    const instances = await enrollmentTemplatesForUser(req, profile);
+  async function currentEnrollmentUsage(req, profile, options = {}) {
+    const instances = await enrollmentTemplatesForRequest(req, profile, { ownerOnly: options.ownerOnly !== false });
     const used = instances.length;
     const config = selectedProfileConfig({ profile, config_profile: profile });
     const max = maxInstancesValue(config.enrollment_limit ?? config.max_templates);
@@ -343,7 +343,8 @@ function registerEnrollRoutes(app, {
   currentEnrollmentUsage,
 }) {
   app.get("/enroll/limit", async (req, res) => {
-    res.json(await currentEnrollmentUsage(req, req.query.profile || ""));
+    const ownerOnly = req.query.owner_only === "false" || req.query.all === "true" ? false : true;
+    res.json(await currentEnrollmentUsage(req, req.query.profile || "", { ownerOnly }));
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "netbox-docker-image-upgrade",
-    "version": "3.9.0",
+    "version": "3.9.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "netbox-docker-image-upgrade",
-            "version": "3.9.0",
+            "version": "3.9.1",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "netbox-docker-image-upgrade",
-    "version": "3.9.0",
+    "version": "3.9.1",
     "description": "App to deploy new image to all containers",
     "author": "vincent@saashup.com",
     "homepage": "https://github.com/SaaShup/netbox-docker-image-upgrade",

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1457,8 +1457,9 @@ async function orderLimitForProfile(profile) {
   return response.json();
 }
 
-async function enrollLimitForProfile(profile) {
+async function enrollLimitForProfile(profile, { ownerOnly = true } = {}) {
   const query = new URLSearchParams({ profile: profile || "" });
+  if (!ownerOnly) query.set("owner_only", "false");
   const response = await fetch(`/enroll/limit?${query.toString()}`, {
     headers: { Accept: "application/json" },
   });
@@ -2583,7 +2584,7 @@ async function refreshCatalog() {
   try {
     const profile = defaultConfigProfileName() || currentConfigProfile || selectedProfileCredentials().profile || "";
     if (profile) applyProfileToFields(profile);
-    const limit = await enrollLimitForProfile(selectedProfileCredentials().profile || profile);
+    const limit = await enrollLimitForProfile(selectedProfileCredentials().profile || profile, { ownerOnly: false });
     renderCatalogItems(limit.instances, limit);
   } catch {
     catalogList.innerHTML = '<div class="catalog-empty catalog-empty-error">Catalog unavailable.</div>';

--- a/tests/e2e/admin.spec.js
+++ b/tests/e2e/admin.spec.js
@@ -2479,6 +2479,7 @@ test("enroll page imports docker run and submits creation", async ({ page }) => 
 });
 
 test("catalog page shows the account menu", async ({ page }) => {
+  let catalogLimitUrl = "";
   await page.route("**/session/user", async (route) => {
     await route.fulfill({
       status: 200,
@@ -2487,6 +2488,7 @@ test("catalog page shows the account menu", async ({ page }) => {
     });
   });
   await page.route("**/enroll/limit**", async (route) => {
+    catalogLimitUrl = route.request().url();
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -2521,6 +2523,7 @@ test("catalog page shows the account menu", async ({ page }) => {
   await expect(page).toHaveURL(/\/catalog$/);
   await expect(page.locator(".catalog-eyebrow")).toHaveText("Template catalog");
   await expect(page.locator(".catalog-summary")).toHaveCount(0);
+  expect(new URL(catalogLimitUrl).searchParams.get("owner_only")).toBe("false");
   await expect(page.locator("#catalogList")).toContainText("flowg");
   await expect(page.locator("#catalogList")).toContainText("linksociety/flowg:v0.58.0");
   await expect(page.locator("#catalogList")).toContainText("Ready");

--- a/tests/unit/server-routes.test.js
+++ b/tests/unit/server-routes.test.js
@@ -2593,6 +2593,17 @@ describe("server routes", () => {
         ]);
       });
 
+    await request.get("/enroll/limit")
+      .set("x-auth-request-email", "owner@example.com")
+      .query({ profile: "prod", owner_only: "false" })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.instances).toEqual([
+          expect.objectContaining({ instance: "OwnerTemplate", image: "saashup/owner", source: "template" }),
+          expect.objectContaining({ instance: "OtherTemplate", image: "saashup/other", source: "template" }),
+        ]);
+      });
+
     await request.get("/templates")
       .set("x-auth-request-email", "owner@example.com")
       .query({ profile: "prod", enroll: "true" })
@@ -2647,6 +2658,17 @@ describe("server routes", () => {
       .expect((res) => {
         expect(res.body.instances).toEqual([
           expect.objectContaining({ instance: "OwnerTemplate", image: "saashup/owner", source: "netbox-template" }),
+        ]);
+      });
+
+    await request.get("/enroll/limit")
+      .set("x-auth-request-email", "owner@example.com")
+      .query({ profile: "prod", owner_only: "false" })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.instances).toEqual([
+          expect.objectContaining({ instance: "OwnerTemplate", image: "saashup/owner", source: "netbox-template" }),
+          expect.objectContaining({ instance: "OtherTemplate", image: "saashup/other", source: "netbox-template" }),
         ]);
       });
 


### PR DESCRIPTION
### Motivation

- Allow the catalog page to show enrollment templates from all owners instead of only the current user by making the enroll limit endpoint opt-in for cross-owner results.
- Provide a query-level switch so callers can explicitly request owner-only or all-owner template listings.
- Bump package version for the release.

### Description

- Extended `currentEnrollmentUsage` to accept an `options` object and pass an `ownerOnly` flag into `enrollmentTemplatesForRequest` via `enrollmentTemplatesForRequest(req, profile, { ownerOnly: options.ownerOnly !== false })`.
- Updated `registerEnrollRoutes` to parse `owner_only` and `all` query parameters and forward them to `currentEnrollmentUsage` when handling `GET /enroll/limit`.
- Updated client code: `enrollLimitForProfile` now accepts an `{ ownerOnly }` option and sets `owner_only=false` on the request when `ownerOnly` is false, and `refreshCatalog` now requests enroll limits with `{ ownerOnly: false }` so the catalog shows all owner templates.
- Added/updated tests to assert the new behavior in unit and E2E suites, and bumped `package.json`/`package-lock.json` version to `3.9.1`.

### Testing

- Ran unit tests (`vitest`) including the `server-routes` tests that exercise `GET /enroll/limit`, and the new assertions for `owner_only=false` passed.
- Ran E2E tests (`playwright`) including the updated `admin.spec` that verifies the catalog requests include `owner_only=false`, and the test passed.
- No automated test failures were observed after these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a299a68e9288333a53de08dc7957550)