### PR TITLE
Refactor sidebar navigation styles, add hover/active indicators, bump version to 3.10.4 and update e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "netbox-docker-image-upgrade",
-    "version": "3.10.3",
+    "version": "3.10.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "netbox-docker-image-upgrade",
-            "version": "3.10.3",
+            "version": "3.10.4",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "netbox-docker-image-upgrade",
-    "version": "3.10.3",
+    "version": "3.10.4",
     "description": "App to deploy new image to all containers",
     "author": "vincent@saashup.com",
     "homepage": "https://github.com/SaaShup/netbox-docker-image-upgrade",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -198,7 +198,7 @@ body.app-booting .app-shell {
   transform: rotate(180deg);
 }
 
-.app-shell.sidebar-collapsed .nav {
+.app-shell.sidebar-collapsed .sidebar .nav {
   justify-items: center;
 }
 
@@ -224,7 +224,7 @@ body.app-booting .app-shell {
   background: rgba(255, 255, 255, 0.16);
 }
 
-.nav {
+.sidebar .nav {
   display: grid;
   gap: 10px;
 }
@@ -243,18 +243,32 @@ body.app-booting .app-shell {
   padding-top: 4px;
 }
 
-.nav-item {
+.sidebar .nav-item {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 10px;
+  overflow: hidden;
   color: #cbd5e1;
   text-decoration: none;
   padding: 12px 14px;
+  border: 1px solid transparent;
   border-radius: 14px;
-  transition: 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease, transform 0.15s ease;
 }
 
-.nav-icon {
+.sidebar .nav-item::before {
+  content: "";
+  position: absolute;
+  inset: 10px auto 10px 0;
+  width: 3px;
+  border-radius: 0 999px 999px 0;
+  background: #6aa2ff;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.sidebar .nav-icon {
   display: grid;
   place-items: center;
   flex: 0 0 18px;
@@ -263,7 +277,7 @@ body.app-booting .app-shell {
   color: currentColor;
 }
 
-.nav-icon svg {
+.sidebar .nav-icon svg {
   width: 18px;
   height: 18px;
   fill: none;
@@ -273,15 +287,43 @@ body.app-booting .app-shell {
   stroke-linejoin: round;
 }
 
-.nav-item:hover,
-.nav-item.active {
-  color: white !important;
-  background: rgba(255, 255, 255, 0.12);
+.sidebar .nav-item:hover,
+.sidebar .nav-item:focus-visible {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+  transform: translateX(3px);
 }
 
-.nav-item.danger:hover,
-.nav-item.danger.active {
-  background: rgba(220, 38, 38, 0.18);
+.sidebar .nav-item.active {
+  color: #ffffff;
+  background: linear-gradient(90deg, rgba(36, 107, 254, 0.42), rgba(255, 255, 255, 0.12));
+  border-color: rgba(106, 162, 255, 0.38);
+  box-shadow: inset 0 0 0 1px rgba(106, 162, 255, 0.10);
+}
+
+.sidebar .nav-item:hover::before,
+.sidebar .nav-item:focus-visible::before,
+.sidebar .nav-item.active::before {
+  opacity: 1;
+}
+
+.sidebar .nav-item.danger:hover,
+.sidebar .nav-item.danger:focus-visible {
+  background: rgba(220, 38, 38, 0.24);
+  border-color: rgba(248, 113, 113, 0.34);
+}
+
+.sidebar .nav-item.danger:hover::before,
+.sidebar .nav-item.danger:focus-visible::before,
+.sidebar .nav-item.danger.active::before {
+  background: #f87171;
+}
+
+.sidebar .nav-item.danger.active {
+  background: linear-gradient(90deg, rgba(220, 38, 38, 0.34), rgba(220, 38, 38, 0.18));
+  border-color: rgba(248, 113, 113, 0.34);
 }
 
 .main {
@@ -402,13 +444,13 @@ body.app-booting .app-shell {
   text-decoration: none;
 }
 
-.nav {
+.site-header .nav {
   display: flex;
   gap: 8px;
   align-items: center;
 }
 
-.nav a {
+.site-header .nav a {
   text-decoration: none;
   color: var(--muted);
   padding: 10px 12px;
@@ -416,12 +458,12 @@ body.app-booting .app-shell {
   font-weight: 700;
 }
 
-.nav a:hover {
+.site-header .nav a:hover {
   color: var(--text);
   background: var(--button-soft);
 }
 
-.nav .nav-cta {
+.site-header .nav .nav-cta {
   color: white;
   background: var(--primary);
 }
@@ -2620,7 +2662,7 @@ body.order-page #orderCancelBtn {
     display: flex;
   }
 
-  .app-shell.sidebar-collapsed .nav {
+  .app-shell.sidebar-collapsed .sidebar .nav {
     justify-items: stretch;
   }
 
@@ -2636,7 +2678,7 @@ body.order-page #orderCancelBtn {
     opacity: 1;
   }
 
-  .nav {
+  .sidebar .nav {
     grid-template-columns: repeat(8, minmax(0, 1fr));
   }
 
@@ -2665,7 +2707,7 @@ body.order-page #orderCancelBtn {
     padding: 20px;
   }
 
-  .nav {
+  .sidebar .nav {
     grid-template-columns: 1fr 1fr;
   }
 

--- a/tests/e2e/admin.spec.js
+++ b/tests/e2e/admin.spec.js
@@ -458,6 +458,14 @@ test("admin sidebar can collapse and expand", async ({ page }) => {
   await expect(loader).toBeHidden();
   await expect(page.locator("body")).not.toHaveClass(/app-booting/);
   await expect(shell).not.toHaveAttribute("aria-busy", "true");
+  await expect(page.locator(".sidebar .nav")).toHaveCSS("display", "grid");
+
+  const templateItem = page.locator("#menu_template");
+  await templateItem.hover();
+  await expect(templateItem).toHaveCSS("background-color", "rgba(255, 255, 255, 0.16)");
+  await expect(templateItem).toHaveCSS("border-color", "rgba(255, 255, 255, 0.18)");
+  await expect(templateItem).toHaveCSS("transform", /matrix\(1, 0, 0, 1, 3, 0\)/);
+
   await expect(toggle).toHaveAttribute("aria-expanded", "true");
   await toggle.click();
   await expect(shell).toHaveClass(/sidebar-collapsed/);


### PR DESCRIPTION
### Motivation

- Improve the sidebar navigation visuals and interaction feedback by adding scoped selectors, visible hover/focus/active states, and an accent indicator bar.
- Reduce style leakage by scoping header and nav rules to `.sidebar` and `.site-header` respectively.
- Publish the patch as version `3.10.4`.

### Description

- Refactored `public/css/style.css` to scope nav rules under `.sidebar` and `.site-header`, added a left accent indicator using `.nav-item::before`, and introduced refined hover, focus-visible, active and danger styles with transitions. 
- Added positioning, overflow, border, box-shadow and transform changes to `.sidebar .nav-item` for improved interaction visuals and accessibility.
- Updated `package.json` and `package-lock.json` to bump the package version from `3.10.3` to `3.10.4`.
- Adjusted the end-to-end test `tests/e2e/admin.spec.js` to assert the new layout and visual states (check `.sidebar .nav` display and hover/focus style expectations on `#menu_template`).

### Testing

- Ran unit tests with `vitest run`, and the suite completed successfully. 
- Ran end-to-end tests with `playwright test`, and the updated e2e assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2acd477c48833382ac8d085dd20845)